### PR TITLE
Update etc.cpp

### DIFF
--- a/src/etc.cpp
+++ b/src/etc.cpp
@@ -797,7 +797,7 @@ ThisConfigStruct *findBrdConfig(int searchId = 0)
       int BSL_PIN_MODE = 0;
       if (CCTool.begin(zbConfigs[zbIdx].rstPin, zbConfigs[zbIdx].bslPin, BSL_PIN_MODE))
       {
-        if (CCTool.detectChipInfo())
+        if (CCTool.detectChipInfo() && ethOk==true)
         {
           zbOk = true;
           LOGD("Zigbee config OK: %d", zbIdx);


### PR DESCRIPTION
If 2 gateways have the same zbconfig, and the ethconfig is only the difference between ethaddr（0or1）, this line（if (CCTool.detectChipInfo()）...） will ignore the eth initialization failure and then directly determine the boardid according to the zbconfig.